### PR TITLE
APP-4030 : PanModal Embed Type 이슈 수정

### DIFF
--- a/PanModal.podspec
+++ b/PanModal.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PanModal'
-  s.version          = '1.4.6'
+  s.version          = '1.4.7'
   s.summary          = 'PanModal is an elegant and highly customizable presentation API for constructing bottom sheet modals on iOS.'
 
 # This description is used to generate tags and improve search results.

--- a/PanModal/Controller/PanModalWrappedViewController.swift
+++ b/PanModal/Controller/PanModalWrappedViewController.swift
@@ -692,7 +692,7 @@ private extension PanModalWrappedViewController {
      */
     func trackScrolling(_ scrollView: UIScrollView) {
         scrollViewYOffset = max(scrollView.contentOffset.y, 0)
-        scrollView.showsVerticalScrollIndicator = true
+        scrollView.showsVerticalScrollIndicator = false
     }
 
     /**

--- a/PanModal/Controller/PanModalWrappedViewController.swift
+++ b/PanModal/Controller/PanModalWrappedViewController.swift
@@ -272,7 +272,6 @@ public extension PanModalWrappedViewController {
      */
     func setNeedsLayoutUpdate() {
         configureViewLayout(presentedVC)
-        adjustPresentedViewFrame()
         observe(scrollView: presentable?.panScrollable)
         configureScrollViewInsets()
     }
@@ -320,15 +319,6 @@ private extension PanModalWrappedViewController {
         }
 
         setNeedsLayoutUpdate()
-    }
-
-    /**
-     Reduce height of presentedView so that it sits at the bottom of the screen
-     */
-    func adjustPresentedViewFrame() {
-        let frame = containerVC.view.frame
-        let adjustedSize = CGSize(width: frame.size.width, height: frame.size.height - anchoredYPosition)
-        presentedVC.view.frame = CGRect(origin: .zero, size: adjustedSize)
     }
 
     func layoutContainer() {

--- a/PanModal/Controller/PanModalWrappedViewController.swift
+++ b/PanModal/Controller/PanModalWrappedViewController.swift
@@ -397,13 +397,6 @@ private extension PanModalWrappedViewController {
         scrollView.scrollIndicatorInsets = presentable?.scrollIndicatorInsets ?? .zero
 
         /**
-         Set the appropriate contentInset as the configuration within this class
-         offsets it
-         */
-
-        scrollView.contentInset.bottom = view.safeAreaInsets.bottom
-
-        /**
          As we adjust the bounds during `handleScrollViewTopBounce`
          we should assume that contentInsetAdjustmentBehavior will not be correct
          */
@@ -479,7 +472,7 @@ private extension PanModalWrappedViewController {
                 let position = nearest(to: presentedView.frame.minY, inValues: [containerVC.view.bounds.height, shortFormYPosition, longFormYPosition])
 
                 if position == longFormYPosition {
-                    transition(to: .shortForm)
+                    transition(to: .longForm)
 
                 } else if position == shortFormYPosition || presentable?.allowsDragToDismiss == false {
                     transition(to: .shortForm)
@@ -760,7 +753,7 @@ extension PanModalWrappedViewController: UIGestureRecognizerDelegate {
      Do not require any other gesture recognizers to fail
      */
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+        return false
     }
 
     /**

--- a/PanModal/Controller/PanModalWrappedViewController.swift
+++ b/PanModal/Controller/PanModalWrappedViewController.swift
@@ -272,6 +272,7 @@ public extension PanModalWrappedViewController {
      */
     func setNeedsLayoutUpdate() {
         configureViewLayout(presentedVC)
+        adjustPresentedViewFrame()
         observe(scrollView: presentable?.panScrollable)
         configureScrollViewInsets()
     }
@@ -319,6 +320,21 @@ private extension PanModalWrappedViewController {
         }
 
         setNeedsLayoutUpdate()
+    }
+    
+    /**
+     Reduce height of presentedView so that it sits at the bottom of the screen
+     */
+    func adjustPresentedViewFrame() {
+        let adjustedPoint = CGPoint(
+            x: .zero,
+            y: presentedVC.shortFormYPos
+        )
+        
+        presentedVC.view.frame = CGRect(
+            origin: adjustedPoint,
+            size: presentedVC.view.frame.size
+        )
     }
 
     func layoutContainer() {


### PR DESCRIPTION
<!-- PR 타이틀에 지라티켓 번호를 기재해 주세요 -->

## Reviewer
- 1st : @jonggilseo 
- 2nd : @yojkim

## Background
<!-- 지라티켓, PRD, 디자인가이드 등 코드리뷰를 위해 참고 되어야 할 사항들을 기재해 주세요 -->
지라티켓: https://croquis.atlassian.net/browse/APP-4030

## Changes
<!-- 변경 사항을 기재해 주세요 -->
1. Panmodal 내부의 CollectionView를 Scrollable 선언 시, TypePanGesture에서 PanModal 확대/축소 이 외 이벤트를 받지 못하는 이슈 
(ex, PanModal 내부의 CollectionView의 Vertical Scroll 불가)
2. ScrollView Inset을 반영하지 못함
3. PanModal의 setNeedsLayoutUpdate 호출 시, PanModal Frame이 비정상적으로 동작
4. Vertical Indicator를 노출 이슈

## Test Guide
<!-- 테스트 방법 혹은 팁을 알려주세요 -->
1. 08/03 기준 dev-ux 서버에서 찜/장바구니 액션을 통해 바텀시트 확인이 가능합니다. 
> * 앱 버전 7.18.0 미만: 한줄 캐러셀 UxTitle, UxCarosel
> * 앱 버전 7.18.0 이상: 두줄 캐러셀 UxGoodsGroup 2개

> 진입 방법
> a. PDP(등록형/연동형) 진입 이후, 하트 버튼 클릭
> b. 등록형 PDP 진입 후, 구매 > 장바구니 담기 클릭

a)  바텀 시트가 모두 열린 후, 컨텐츠 스크롤 여부
b)  캐러셀에 대해 Vertical 스크롤 정상 동작 여부
c) Bottom Scroll을 통해 바텀 시트 닫힘 여부
d) 이외 UI가 깨지지 않는지

> 진입 방법
> a. PDP(등록형/연동형) 진입 이후, 하트 버튼 클릭
> b. 등록형 PDP 진입 후, 구매 > 장바구니 담기 클릭

2. Embed Style 사용하는 UI
2.1 SimilarProductsBottomSheetViewController  정상 동작 여부
> 진입방법
> a. CLP 에서 하트 버튼 클릭

## Important
<!-- 주안점을 기재해 주세요 -->
연관 상품 바텀시트의 데이터는 **앱 버전(7.18.0)에 따라 API 결과가 다릅니다.**