### PR TITLE
APP-7009 어필레이트 뷰 구현을 위한 CustomTopView 구현

### DIFF
--- a/PanModal/Animator/PanModalPresentationAnimator.swift
+++ b/PanModal/Animator/PanModalPresentationAnimator.swift
@@ -60,13 +60,18 @@ public class PanModalPresentationAnimator: NSObject {
 
         // Use panView as presentingView if it already exists within the containerView
         let panView: UIView = transitionContext.containerView.panContainerView ?? toVC.view
+        let topView = transitionContext.containerView.customTopView
 
         // Move presented view offscreen (from the bottom)
         panView.frame = transitionContext.finalFrame(for: toVC)
         panView.frame.origin.y = transitionContext.containerView.frame.height
+        topView?.alpha = 0
+        topView?.frame.origin.y = transitionContext.containerView.frame.height + (presentable?.customTopView?.frame.height ?? 0)
 
         PanModalAnimator.animate({
             panView.frame.origin.y = yPos
+            topView?.frame.origin.y = yPos + (presentable?.customTopView?.frame.height ?? 0)
+            topView?.alpha = 1
         }, config: presentable) { didComplete in
             transitionContext.completeTransition(didComplete)
         }
@@ -82,9 +87,12 @@ public class PanModalPresentationAnimator: NSObject {
 
         let presentable = fromVC as? PanModalPresentable.LayoutType
         let panView: UIView = transitionContext.containerView.panContainerView ?? fromVC.view
-
+        let topView = transitionContext.containerView.customTopView
+        
         PanModalAnimator.animate({
             panView.frame.origin.y = transitionContext.containerView.frame.height + PanModalPresentationController.Constants.dragIndicatorHeight
+            topView?.frame.origin.y = transitionContext.containerView.frame.height + PanModalPresentationController.Constants.dragIndicatorHeight - (presentable?.customTopView?.frame.height ?? 0) * 1.5
+            topView?.alpha = 0.0
         }, config: presentable) { didComplete in
             fromVC.view.removeFromSuperview()
             transitionContext.completeTransition(didComplete)

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -136,6 +136,8 @@ public class PanModalPresentationController: UIPresentationController {
     public override var presentedView: UIView {
         return panContainerView
     }
+    
+    public var customTopView: UIView?
 
     // MARK: - Gesture Recognizers
 
@@ -339,6 +341,13 @@ private extension PanModalPresentationController {
         if presentable.showDragIndicator {
             addDragIndicatorView(to: presentedView)
         }
+        
+        if let customTopView = customTopView {
+            containerView.addSubview(customTopView)
+            customTopView.translatesAutoresizingMaskIntoConstraints = false
+            customTopView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
+            customTopView.bottomAnchor.constraint(equalTo: dragIndicatorView.topAnchor, constant: -10).isActive = true
+        }
 
         setNeedsLayoutUpdate()
         adjustPanContainerBackgroundColor()
@@ -379,7 +388,6 @@ private extension PanModalPresentationController {
         backgroundView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
         backgroundView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor).isActive = true
     }
-
     /**
      Adds the drag indicator view to the view hierarchy
      & configures its layout constraints.

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -136,8 +136,6 @@ public class PanModalPresentationController: UIPresentationController {
     public override var presentedView: UIView {
         return panContainerView
     }
-    
-    public var customTopView: UIView?
 
     // MARK: - Gesture Recognizers
 
@@ -206,6 +204,7 @@ public class PanModalPresentationController: UIPresentationController {
     override public func presentationTransitionDidEnd(_ completed: Bool) {
         if completed { return }
 
+        presentable?.customTopView?.removeFromSuperview()
         backgroundView.removeFromSuperview()
     }
 
@@ -342,12 +341,7 @@ private extension PanModalPresentationController {
             addDragIndicatorView(to: presentedView)
         }
         
-        if let customTopView = customTopView {
-            containerView.addSubview(customTopView)
-            customTopView.translatesAutoresizingMaskIntoConstraints = false
-            customTopView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
-            customTopView.bottomAnchor.constraint(equalTo: dragIndicatorView.topAnchor, constant: -10).isActive = true
-        }
+        addCustomTopViewIfExisted(in: containerView)
 
         setNeedsLayoutUpdate()
         adjustPanContainerBackgroundColor()
@@ -388,6 +382,18 @@ private extension PanModalPresentationController {
         backgroundView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
         backgroundView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor).isActive = true
     }
+    
+    
+    func addCustomTopViewIfExisted(in containerView: UIView) {
+        guard let customTopView = presentable?.customTopView else { return }
+        containerView.addSubview(customTopView)
+        customTopView.translatesAutoresizingMaskIntoConstraints = false
+        customTopView.leftAnchor.constraint(equalTo: containerView.leftAnchor).isActive = true
+        customTopView.rightAnchor.constraint(equalTo: containerView.rightAnchor).isActive = true
+        customTopView.bottomAnchor.constraint(equalTo: dragIndicatorView.topAnchor, constant: -10).isActive = true
+        customTopView.heightAnchor.constraint(equalToConstant: customTopView.frame.height).isActive = true
+    }
+    
     /**
      Adds the drag indicator view to the view hierarchy
      & configures its layout constraints.

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -77,6 +77,10 @@ public extension PanModalPresentable where Self: UIViewController {
     var showDragIndicator: Bool {
         return true
     }
+    
+    var customTopView: CustomTopView? {
+        return nil
+    }
 
     func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
         return true

--- a/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
+++ b/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
@@ -92,7 +92,9 @@ extension PanModalPresentable where Self: UIViewController {
 
         }
 
-        return container.bounds.size.height - topOffset
+        let customTopViewHeight = customTopView?.frame.height ?? 0
+
+        return container.bounds.size.height - topOffset - customTopViewHeight
     }
 
     /**

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -134,6 +134,8 @@ public protocol PanModalPresentable {
      */
     var showDragIndicator: Bool { get }
 
+    var customTopView: CustomTopView? { get }
+
     /**
      Asks the delegate if the pan modal should respond to the pan modal gesture recognizer.
      

--- a/PanModal/View/CustomTopView.swift
+++ b/PanModal/View/CustomTopView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class CustomTopView: UIView {
+open class CustomTopView: UIView {
     
 }
 

--- a/PanModal/View/CustomTopView.swift
+++ b/PanModal/View/CustomTopView.swift
@@ -1,0 +1,19 @@
+//
+//  CustomTopView.swift
+//  PanModal
+//
+//  Created by Hyun Sik Yoo on 2023/06/05.
+//  Copyright © 2023 Detail. All rights reserved.
+//
+
+import UIKit
+
+public class CustomTopView: UIView {
+    
+}
+
+extension UIView {
+    var customTopView: CustomTopView? {
+        return subviews.compactMap({ $0 as? CustomTopView }).first
+    }
+}

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		638A9380256B4DC500A5E00B /* PanModalWrappedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638A937F256B4DC500A5E00B /* PanModalWrappedViewController.swift */; };
 		638A9383256B4E3F00A5E00B /* PanModalWrappedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638A937F256B4DC500A5E00B /* PanModalWrappedViewController.swift */; };
 		638A938D256BB26E00A5E00B /* EmbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638A9387256BB21800A5E00B /* EmbedViewController.swift */; };
+		6E763B4C2A2E2313002A77E8 /* CustomTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E763B4B2A2E2313002A77E8 /* CustomTopView.swift */; };
+		6E763B4D2A2E25A2002A77E8 /* CustomTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E763B4B2A2E2313002A77E8 /* CustomTopView.swift */; };
 		743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */; };
 		743CABB22225FD1100634A5A /* UserGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */; };
 		743CABB42225FE7700634A5A /* UserGroupMemberPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */; };
@@ -99,6 +101,7 @@
 		0F2A2C542239C119003BDB2F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		638A937F256B4DC500A5E00B /* PanModalWrappedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanModalWrappedViewController.swift; sourceTree = "<group>"; };
 		638A9387256BB21800A5E00B /* EmbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedViewController.swift; sourceTree = "<group>"; };
+		6E763B4B2A2E2313002A77E8 /* CustomTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTopView.swift; sourceTree = "<group>"; };
 		743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupViewController.swift; sourceTree = "<group>"; };
 		743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupHeaderView.swift; sourceTree = "<group>"; };
 		743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupMemberPresentable.swift; sourceTree = "<group>"; };
@@ -321,6 +324,7 @@
 				DC13906E216D9458007A3E64 /* DimmedView.swift */,
 				94795C9C21F03368008045A0 /* PanContainerView.swift */,
 				D134CC7022641B350022AA29 /* IndicatorView.swift */,
+				6E763B4B2A2E2313002A77E8 /* CustomTopView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -541,6 +545,7 @@
 				0F2A2C622239C148003BDB2F /* PanModalHeight.swift in Sources */,
 				0F2A2C632239C14B003BDB2F /* PanModalPresentable.swift in Sources */,
 				0F2A2C642239C14E003BDB2F /* PanModalPresentable+Defaults.swift in Sources */,
+				6E763B4C2A2E2313002A77E8 /* CustomTopView.swift in Sources */,
 				0F2A2C652239C151003BDB2F /* PanModalPresentable+UIViewController.swift in Sources */,
 				0F2A2C662239C153003BDB2F /* PanModalPresentable+LayoutHelpers.swift in Sources */,
 				0F2A2C672239C157003BDB2F /* PanModalPresenter.swift in Sources */,
@@ -587,6 +592,7 @@
 				DC139061216D93ED007A3E64 /* SampleViewController.swift in Sources */,
 				743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */,
 				638A938D256BB26E00A5E00B /* EmbedViewController.swift in Sources */,
+				6E763B4D2A2E25A2002A77E8 /* CustomTopView.swift in Sources */,
 				DCC0EE7C21917F2500208DBC /* PanModalPresentable+Defaults.swift in Sources */,
 				94795C9D21F03368008045A0 /* PanContainerView.swift in Sources */,
 				74C072A7220BA78800124CE1 /* PanModalPresentable+LayoutHelpers.swift in Sources */,

--- a/Sample/View Controllers/BasicViewController.swift
+++ b/Sample/View Controllers/BasicViewController.swift
@@ -33,4 +33,36 @@ extension BasicViewController: PanModalPresentable {
     var anchorModalToLongForm: Bool {
         return false
     }
+    
+    var customTopView: CustomTopView? {
+        return TopView()
+    }
+}
+
+extension BasicViewController {
+    final class TopView: CustomTopView {
+        enum Layout {
+            static let size = CGSize(width: UIScreen.main.bounds.width, height: 50)
+        }
+        
+        private let affiliateSwitch = UISwitch()
+        
+        override init(frame: CGRect) {
+            super.init(frame: .init(origin: .zero, size: Layout.size))
+            
+            setupUI()
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+        private func setupUI() {
+            addSubview(affiliateSwitch)
+            
+            affiliateSwitch.translatesAutoresizingMaskIntoConstraints = false
+            affiliateSwitch.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+            affiliateSwitch.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        }
+    }
 }


### PR DESCRIPTION
## Desired Date 
<!-- 코드리뷰 완료 희망 날짜 -->
5/14
## Reviewer
- 1st :
- 2nd :

## Spec
<!-- 지라티켓, PRD, 디자인가이드, 로그명세 등 코드리뷰를 위해 참고되어야 할 사항들을 기재해 주세요 -->
- [APP-7009 [iOS] 어필레이트 > PDP 바텀싯 문구노출](https://croquis.atlassian.net/browse/APP-7009)

## 변경사항
<!-- 변경 사항을 기재해 주세요 -->
- PDP > 상품 공유하기 버튼 터치 시, 발생하는 공유 바텀시트에서 어필레이트 뷰를 활성화시키기 위해 커스터마이징 진행했습니다.
- PanModal 바텀시트 상단에 사용자가 커스터마이징한 뷰 추가할 수 있도록 CustomTopView 구현
<img src="https://github.com/croquiscom/PanModal/assets/7058293/a294d82f-648c-43f3-9c9c-544fe8454d60" width=360>


### 영향범위
<!-- 변경사항이 영향을 끼치는 화면과 기능을 기재해 주세요 -->
- CustomTopView를 사용하지 않는 기존 바텀시트들 정상 동작 하는가?

## 테스트
### 테스트 환경
<!-- 테스트에 필요한 환경 / 계정 / 상품정보 등의 데이터를 기재해 주세요 -->
- Alpha, Dev(dev-e-affiliate) PDP에서 공유 버튼 터치 시, 확인 가능합니다.
    - feature/APP-7009-affiliate 브랜치에서 지그재그에 적용된 버전으로 확인 가능합니다.
- 혹은 PanModal 프로젝트 데모앱에서도 확인 가능합니다.

### 테스트케이스 (요구사항, 기대결과)
<!-- 성공/실패, 경우의 수 모두 테스트케이스를 작성해 주세요 -->
<!-- 플로우, 상황별 데이터, 노출/노출조건, 액션, 에러 등 다양한 케이스를 고려하여 기재해 주세요 -->
<!-- 해당 테스트케이스의 기대 결과도 작성해 주세요. (예: 로그인 되어 있지 않은 유저일 경우 메인탭 상단에 배너 노출) -->
- CustomTopView 설정 시, 바텀시트 위에 정상적으로 노출되는가?
    - present, dismiss 애니메이션때도 같이 나오는가?
- CustomTopView를 사용하지 않는 바텀시트는 기존 그대로 정상동작 하는가?