### PR TITLE
APP-7541 바텀시트 상단 indicator 색상 컨트롤 기능 추가 및 백그라운드 터치 조절 비활성화 추가

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -111,7 +111,10 @@ public class PanModalPresentationController: UIPresentationController {
             view = DimmedView()
         }
         view.didTap = { [weak self] _ in
-            self?.dismissPresentedViewController()
+            if self?.presentable?.allowsTapToDismiss == true {
+                self?.dismissPresentedViewController()
+            }
+            
         }
         return view
     }()

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -404,6 +404,7 @@ private extension PanModalPresentationController {
      */
     func addDragIndicatorView(to view: UIView) {
         view.addSubview(dragIndicatorView)
+        dragIndicatorView.indicator.backgroundColor = presentable?.indicatorColor
         dragIndicatorView.backgroundColor = presentable?.dragIndicatorBackgroundColor
         dragIndicatorView.translatesAutoresizingMaskIntoConstraints = false
         dragIndicatorView.bottomAnchor.constraint(equalTo: view.topAnchor, constant: 0.5).isActive = true

--- a/PanModal/Controller/PanModalWrappedViewController.swift
+++ b/PanModal/Controller/PanModalWrappedViewController.swift
@@ -376,6 +376,7 @@ private extension PanModalWrappedViewController {
      */
     func addDragIndicatorView(to view: UIView) {
         view.addSubview(dragIndicatorView)
+        dragIndicatorView.indicator.backgroundColor = presentable?.dragIndicatorBackgroundColor
         dragIndicatorView.backgroundColor = presentable?.dragIndicatorBackgroundColor
         dragIndicatorView.translatesAutoresizingMaskIntoConstraints = false
         dragIndicatorView.bottomAnchor.constraint(equalTo: view.topAnchor, constant: 0.5).isActive = true

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -85,6 +85,10 @@ public extension PanModalPresentable where Self: UIViewController {
     var panCustomTopView: PanCustomTopView? {
         return nil
     }
+    
+    var indicatorColor: UIColor {
+        return UIColor(red: 241/255.0, green: 243/255.0, blue: 245/255.0, alpha: 1)
+    }
 
     func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
         return true

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -66,6 +66,10 @@ public extension PanModalPresentable where Self: UIViewController {
         return true
     }
     
+    var allowsTapToDismiss: Bool {
+        return true
+    }
+    
     var allowScrollViewDragToDismiss: Bool {
         return true
     }

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -140,6 +140,8 @@ public protocol PanModalPresentable {
      Default value is true.
      */
     var showDragIndicator: Bool { get }
+    
+    var indicatorColor: UIColor { get }
 
     var panCustomTopView: PanCustomTopView? { get }
 

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -111,6 +111,13 @@ public protocol PanModalPresentable {
      Default value is true.
      */
     var allowsDragToDismiss: Bool { get }
+    
+    /**
+     A flag to determine if dismissal should be initiated when tapping on the dimmed background view.
+     
+     Default value is true.
+     */
+    var allowsTapToDismiss: Bool { get }
 
     /**
      Default value is true

--- a/PanModal/View/IndicatorView.swift
+++ b/PanModal/View/IndicatorView.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 class IndicatorView: UIView {
+    let indicator = UIView()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -23,8 +25,6 @@ class IndicatorView: UIView {
     }
 
     private func addIndicatorView() {
-        let indicator = UIView()
-        indicator.backgroundColor = UIColor(red: 241/255.0, green: 243/255.0, blue: 245/255.0, alpha: 1)
         indicator.layer.cornerRadius = 2
         indicator.translatesAutoresizingMaskIntoConstraints = false
         indicator.widthAnchor.constraint(equalToConstant: 40).isActive = true

--- a/Sample/View Controllers/BasicViewController.swift
+++ b/Sample/View Controllers/BasicViewController.swift
@@ -38,6 +38,10 @@ extension BasicViewController: PanModalPresentable {
     var panCustomTopView: PanCustomTopView? {
         return topView
     }
+    
+    var indicatorColor: UIColor {
+        return .red
+    }
 }
 
 extension BasicViewController {

--- a/Sample/View Controllers/BasicViewController.swift
+++ b/Sample/View Controllers/BasicViewController.swift
@@ -42,6 +42,10 @@ extension BasicViewController: PanModalPresentable {
     var indicatorColor: UIColor {
         return .red
     }
+    
+    var allowsTapToDismiss: Bool {
+        return false
+    }
 }
 
 extension BasicViewController {


### PR DESCRIPTION
## Desired Date 
<!-- 코드리뷰 완료 희망 날짜 -->
9/8

## Reviewer
- 1st : @Haccoon 


## Spec
<!-- 지라티켓, PRD, 디자인가이드, 로그명세 등 코드리뷰를 위해 참고되어야 할 사항들을 기재해 주세요 -->
- [APP-7541 오늘의 혜택 '톡라운지'  작성화면, 사진 업로드, 골라줘](https://croquis.atlassian.net/browse/APP-7541)

## 변경사항
<!-- 변경 사항을 기재해 주세요 -->
1. 모달 생성 시, 뒤쪽에 딤처리된 배경의 터치 이벤트 적용 여부를 컨트롤 할 수 있는 설정값을 추가했습니다.
    - 톡라운지 요구사항: 바텀시트 생성시 메뉴를 선택하기 전까지는 모달을 닫을 수 없다. (취소 불가)
    - 해당 기능은 [PanModal 최신 라이브러리](https://github.com/slackhq/PanModal/blob/b2f5bd7d169cba564d5c5b7203864f79be3fe826/PanModal/Controller/PanModalPresentationController.swift#L114-L119)에는 적용된 기능이라 코드 그대로 가져왔습니다.
2. 모달 상단에 있는 indicator 색상을 변경할 수 있도록 설정값을 추가했습니다.
    - 톡라운지 요구사항: indicator는 없지만 상단에 radius적용된 모달을 사용
<img src="https://github.com/croquiscom/PanModal/assets/140593088/769c03e9-c1bb-403e-90c5-0d8c2fb67daa" width=360>


### 영향범위
<!-- 변경사항이 영향을 끼치는 화면과 기능을 기재해 주세요 -->
- 기존 바텀시트들 제대로 동작하는가?

## 테스트
### 테스트 환경
<!-- 테스트에 필요한 환경 / 계정 / 상품정보 등의 데이터를 기재해 주세요 -->
- 데모앱의 Basic에 해당 기능을 적용했습니다. (백그라운드 터치 불가 및 indicator 색상 변경)
<img src="https://github.com/croquiscom/PanModal/assets/140593088/605ca6d6-0db5-49fa-9f61-acedc8001524" width=360>


### 테스트케이스 (요구사항, 기대결과)
<!-- 성공/실패, 경우의 수 모두 테스트케이스를 작성해 주세요 -->
<!-- 플로우, 상황별 데이터, 노출/노출조건, 액션, 에러 등 다양한 케이스를 고려하여 기재해 주세요 -->
<!-- 해당 테스트케이스의 기대 결과도 작성해 주세요. (예: 로그인 되어 있지 않은 유저일 경우 메인탭 상단에 배너 노출) -->
- 백그라운드 터치가 disable되었는가?
- indicator가 다른 색상으로 변경되었는가?