### PR TITLE
APP-10195 : 카테고리 바텀시트 > CLP 전환 시 > 우->좌 전환 + Swipe Back 가능하도록 변경

### DIFF
--- a/PanModal/Controller/OverContextNavigationController.swift
+++ b/PanModal/Controller/OverContextNavigationController.swift
@@ -1,0 +1,49 @@
+import UIKit
+
+public class OverContextNavigationController: UINavigationController {
+    private let panModal: UIViewController & OverContextPanModalPresentable
+    
+    init(panModal: UIViewController & OverContextPanModalPresentable) {
+        self.panModal = panModal
+        super.init(nibName: nil, bundle: nil)
+        
+        isNavigationBarHidden = true
+        modalPresentationStyle = .overCurrentContext
+        view.backgroundColor = .clear
+        interactivePopGestureRecognizer?.delegate = nil
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        panModal.viewDidLoad()
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        panModal.viewWillAppear(animated)
+    }
+    
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        panModal.viewDidAppear(animated)
+    }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        panModal.viewWillDisappear(animated)
+    }
+    
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        panModal.viewDidDisappear(animated)
+    }
+}

--- a/PanModal/Controller/OverContextNavigationController.swift
+++ b/PanModal/Controller/OverContextNavigationController.swift
@@ -1,9 +1,11 @@
 import UIKit
 
+public typealias OverContextPanModal = UIViewController & OverContextPanModalPresentable
+
 public class OverContextNavigationController: UINavigationController {
-    private let panModal: UIViewController & OverContextPanModalPresentable
+    private weak var panModal: OverContextPanModal?
     
-    init(panModal: UIViewController & OverContextPanModalPresentable) {
+    init(panModal: OverContextPanModal) {
         self.panModal = panModal
         super.init(nibName: nil, bundle: nil)
         
@@ -20,30 +22,30 @@ public class OverContextNavigationController: UINavigationController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
-        panModal.viewDidLoad()
+        panModal?.viewDidLoad()
     }
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        panModal.viewWillAppear(animated)
+        panModal?.viewWillAppear(animated)
     }
     
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        panModal.viewDidAppear(animated)
+        panModal?.viewDidAppear(animated)
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
-        panModal.viewWillDisappear(animated)
+        panModal?.viewWillDisappear(animated)
     }
     
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         
-        panModal.viewDidDisappear(animated)
+        panModal?.viewDidDisappear(animated)
     }
 }

--- a/PanModal/Controller/PanModalWrappedViewController.swift
+++ b/PanModal/Controller/PanModalWrappedViewController.swift
@@ -185,6 +185,7 @@ public extension PanModalWrappedViewController {
         }, config: presentable) { [weak self] _ in
             guard let self = self else { return }
 
+            presentable?.panModalDidDismiss()
             self.removeParent(self)
             self.isPresentedViewAnimating = false
         }

--- a/PanModal/Presentable/OverContextPanModalPresentable.swift
+++ b/PanModal/Presentable/OverContextPanModalPresentable.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public protocol OverContextPanModalPresentable: PanModalPresentable {
+    
+}
+
+extension OverContextPanModalPresentable where Self: UIViewController {
+    var presentStyle: PanModalPresentStyle {
+        return .embed
+    }
+    
+    func panModalDidDismiss() {
+        presentingViewController?.dismiss(animated: false)
+    }
+}

--- a/PanModal/Presentable/OverContextPanModalPresentable.swift
+++ b/PanModal/Presentable/OverContextPanModalPresentable.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 public protocol OverContextPanModalPresentable: PanModalPresentable {
     

--- a/PanModal/Presentable/OverContextPanModalPresentable.swift
+++ b/PanModal/Presentable/OverContextPanModalPresentable.swift
@@ -5,11 +5,11 @@ public protocol OverContextPanModalPresentable: PanModalPresentable {
 }
 
 extension OverContextPanModalPresentable where Self: UIViewController {
-    var presentStyle: PanModalPresentStyle {
+    public var presentStyle: PanModalPresentStyle {
         return .embed
     }
     
-    func panModalDidDismiss() {
+    public func panModalDidDismiss() {
         presentingViewController?.dismiss(animated: false)
     }
 }

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -114,4 +114,7 @@ public extension PanModalPresentable where Self: UIViewController {
 
     }
 
+    func panModalDidDismiss() {
+        
+    }
 }

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -198,5 +198,6 @@ public protocol PanModalPresentable {
      Default value is an empty implementation.
      */
     func panModalWillDismiss()
-
+    
+    func panModalDidDismiss()
 }

--- a/PanModal/Presenter/UIViewController+PanModalPresenter.swift
+++ b/PanModal/Presenter/UIViewController+PanModalPresenter.swift
@@ -59,7 +59,7 @@ extension UIViewController: PanModalPresenter {
 
     }
     
-    public func presentOverContextPanModal(_ viewControllerToPresent: UIViewController & OverContextPanModalPresentable) {
+    public func presentOverContextPanModal(_ viewControllerToPresent: OverContextPanModal) {
         let overContextNavigationViewController = OverContextNavigationController(panModal: viewControllerToPresent)
         
         present(overContextNavigationViewController, animated: false) {

--- a/PanModal/Presenter/UIViewController+PanModalPresenter.swift
+++ b/PanModal/Presenter/UIViewController+PanModalPresenter.swift
@@ -58,4 +58,12 @@ extension UIViewController: PanModalPresenter {
         }
 
     }
+    
+    public func presentOverContextPanModal(_ viewControllerToPresent: UIViewController & OverContextPanModalPresentable) {
+        let overContextNavigationViewController = OverContextNavigationController(panModal: viewControllerToPresent)
+        
+        present(overContextNavigationViewController, animated: false) {
+            overContextNavigationViewController.presentPanModal(viewControllerToPresent)
+        }
+    }
 }

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		74C072A5220BA76D00124CE1 /* PanModalHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C072A4220BA76D00124CE1 /* PanModalHeight.swift */; };
 		74C072A7220BA78800124CE1 /* PanModalPresentable+LayoutHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C072A6220BA78800124CE1 /* PanModalPresentable+LayoutHelpers.swift */; };
 		74C072AA220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C072A9220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift */; };
+		8E3DC78A2BEB24FA00F0A025 /* OverContextNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED0BEA82BE4BA110094D900 /* OverContextNavigationController.swift */; };
+		8E3DC78B2BEB251B00F0A025 /* OverContextPanModalPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED0BEA62BE4B9DF0094D900 /* OverContextPanModalPresentable.swift */; };
 		943904EB2226354100859537 /* BasicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943904EA2226354100859537 /* BasicViewController.swift */; };
 		943904ED2226366700859537 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943904EC2226366700859537 /* AlertViewController.swift */; };
 		943904EF2226383700859537 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943904EE2226383700859537 /* NavigationController.swift */; };
@@ -586,9 +588,11 @@
 				743CB2AA222660D100665A55 /* StackedProfileViewController.swift in Sources */,
 				943904EB2226354100859537 /* BasicViewController.swift in Sources */,
 				DC139073216D9458007A3E64 /* PanModalPresenter.swift in Sources */,
+				8E3DC78B2BEB251B00F0A025 /* OverContextPanModalPresentable.swift in Sources */,
 				943904EF2226383700859537 /* NavigationController.swift in Sources */,
 				DC3B2EBE222A58C9000C8A4A /* AlertView.swift in Sources */,
 				74C072A5220BA76D00124CE1 /* PanModalHeight.swift in Sources */,
+				8E3DC78A2BEB24FA00F0A025 /* OverContextNavigationController.swift in Sources */,
 				94795C9B21F0335D008045A0 /* PanModalPresentationDelegate.swift in Sources */,
 				943904F32226484F00859537 /* UserGroupStackedViewController.swift in Sources */,
 				74C072AA220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift in Sources */,

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		638A938D256BB26E00A5E00B /* EmbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638A9387256BB21800A5E00B /* EmbedViewController.swift */; };
 		6E763B4C2A2E2313002A77E8 /* CustomTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E763B4B2A2E2313002A77E8 /* CustomTopView.swift */; };
 		6E763B4D2A2E25A2002A77E8 /* CustomTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E763B4B2A2E2313002A77E8 /* CustomTopView.swift */; };
+		6ED0BEA72BE4B9DF0094D900 /* OverContextPanModalPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED0BEA62BE4B9DF0094D900 /* OverContextPanModalPresentable.swift */; };
+		6ED0BEA92BE4BA110094D900 /* OverContextNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED0BEA82BE4BA110094D900 /* OverContextNavigationController.swift */; };
 		743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */; };
 		743CABB22225FD1100634A5A /* UserGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */; };
 		743CABB42225FE7700634A5A /* UserGroupMemberPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */; };
@@ -102,6 +104,8 @@
 		638A937F256B4DC500A5E00B /* PanModalWrappedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanModalWrappedViewController.swift; sourceTree = "<group>"; };
 		638A9387256BB21800A5E00B /* EmbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedViewController.swift; sourceTree = "<group>"; };
 		6E763B4B2A2E2313002A77E8 /* CustomTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTopView.swift; sourceTree = "<group>"; };
+		6ED0BEA62BE4B9DF0094D900 /* OverContextPanModalPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverContextPanModalPresentable.swift; sourceTree = "<group>"; };
+		6ED0BEA82BE4BA110094D900 /* OverContextNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverContextNavigationController.swift; sourceTree = "<group>"; };
 		743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupViewController.swift; sourceTree = "<group>"; };
 		743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupHeaderView.swift; sourceTree = "<group>"; };
 		743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupMemberPresentable.swift; sourceTree = "<group>"; };
@@ -305,6 +309,7 @@
 				DCC0EE7B21917F2500208DBC /* PanModalPresentable+Defaults.swift */,
 				DC139069216D9458007A3E64 /* PanModalPresentable+UIViewController.swift */,
 				74C072A6220BA78800124CE1 /* PanModalPresentable+LayoutHelpers.swift */,
+				6ED0BEA62BE4B9DF0094D900 /* OverContextPanModalPresentable.swift */,
 			);
 			path = Presentable;
 			sourceTree = "<group>";
@@ -314,6 +319,7 @@
 			children = (
 				638A937F256B4DC500A5E00B /* PanModalWrappedViewController.swift */,
 				DC13906C216D9458007A3E64 /* PanModalPresentationController.swift */,
+				6ED0BEA82BE4BA110094D900 /* OverContextNavigationController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -541,12 +547,14 @@
 				0F2A2C5E2239C137003BDB2F /* PanModalAnimator.swift in Sources */,
 				0F2A2C5F2239C139003BDB2F /* PanModalPresentationAnimator.swift in Sources */,
 				0F2A2C602239C13C003BDB2F /* PanModalPresentationController.swift in Sources */,
+				6ED0BEA92BE4BA110094D900 /* OverContextNavigationController.swift in Sources */,
 				0F2A2C612239C140003BDB2F /* PanModalPresentationDelegate.swift in Sources */,
 				0F2A2C622239C148003BDB2F /* PanModalHeight.swift in Sources */,
 				0F2A2C632239C14B003BDB2F /* PanModalPresentable.swift in Sources */,
 				0F2A2C642239C14E003BDB2F /* PanModalPresentable+Defaults.swift in Sources */,
 				6E763B4C2A2E2313002A77E8 /* CustomTopView.swift in Sources */,
 				0F2A2C652239C151003BDB2F /* PanModalPresentable+UIViewController.swift in Sources */,
+				6ED0BEA72BE4B9DF0094D900 /* OverContextPanModalPresentable.swift in Sources */,
 				0F2A2C662239C153003BDB2F /* PanModalPresentable+LayoutHelpers.swift in Sources */,
 				0F2A2C672239C157003BDB2F /* PanModalPresenter.swift in Sources */,
 				D134CC7122641B350022AA29 /* IndicatorView.swift in Sources */,


### PR DESCRIPTION
### 리뷰 기한
- 5/8

### 참고자료
- [[iOS] 카테고리 바텀시트 > CLP 전환 시 > 우->좌 전환 + Swipe Back 가능하도록 변경](https://croquis.atlassian.net/browse/APP-10195)
- 지그재그에 적용한 PR과 같이 봐주시면 감사하겠습니다 🙇‍♂️ (카테고리 바텀시트)

### 배경
- AOS와 동일하게 PanModal이 뜬 상태에서 push가 가능하고, swipe back 했을 시, 바텀시트가 남아있도록 하기 위함
- embed 타입은 push가 가능하지만 탭바에서 실행했을 경우, 탭바 위로 present되어 사용할 수 없는 상황

### 적용 아이디어
1. 탭바 위에 투명 NavigationController 생성하여 present
2. 투명 NavigationController에서 원래 노출시키려던 panModal을 `embed` 타입으로 노출
3. embed된 panModal에서 push 시키면 의도대로 동작

<img width="918" alt="image" src="https://github.com/croquiscom/PanModal/assets/140593088/083246f4-33f9-485f-8908-662bc7d77eb0">


https://github.com/croquiscom/PanModal/assets/140593088/100771e0-d3af-473a-bf66-84c44c8faa7a

